### PR TITLE
Add param to set whether to save on reorder

### DIFF
--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -5,7 +5,8 @@ import dragula from 'dragula';
 
 export default class extends Controller {
   static values = {
-    reorderPath: String
+    reorderPath: String,
+    saveOnReorder: { type: Boolean, default: true }
   }
 
   connect() {
@@ -41,7 +42,9 @@ export default class extends Controller {
       },
     }).on('drop', function (el) {
       // save order here.
-      self.saveSortOrder()
+      if (self.saveOnReorderValue) {
+        self.saveSortOrder()
+      }
     }).on('over', function (el, container) {
       // deselect any text fields, or else things go slow!
       $(document.activeElement).blur()


### PR DESCRIPTION
Co-dependent PRs:  
- https://github.com/bullet-train-co/bullet_train-base/pull/80
- (A PR in [bullet_train](https://github.com/bullet-train-co/bullet_train) should be added for tests)

This PR addresses the changes to the Stimulus controller:
- [X] Add the `saveOnReorder` boolean value, defaulting to `true`

Note: this PR is on top of unmerged PR #6, which introduces the Stimulus controller. The merge target branch is `add-sortable-stimulus-controller` for that reason.