### PR TITLE
Re-issue dragula events as native events

### DIFF
--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -7,6 +7,9 @@ export default class extends Controller {
   static values = {
     reorderPath: String
   }
+  
+  // will be reissued as native dom events name prepended with 'sortable:' e.g. 'sortable:drag', 'sortable:drop', etc
+  static pluginEventsToReissue = [ "drag", "dragend", "drop", "cancel", "remove", "shadow", "over", "out", "cloned" ]
 
   connect() {
     if (!this.hasReorderPathValue) { return }
@@ -45,6 +48,16 @@ export default class extends Controller {
     }).on('over', function (el, container) {
       // deselect any text fields, or else things go slow!
       $(document.activeElement).blur()
+    })
+    
+    this.initReissuePluginEventsAsNativeEvents()
+  }
+  
+  initReissuePluginEventsAsNativeEvents() {
+    this.constructor.pluginEventsToReissue.forEach((eventName) => {
+      this.plugin.on(eventName, (...args) => {
+        this.dispatch(eventName, { detail: { plugin: 'dragula', type: eventName, args: args }})
+      })
     })
   }
 


### PR DESCRIPTION
Add ability to catch events such as `drag`, `drop`, `cancel`, etc from the underlying `dragula` library by re-issuing those as native events.

Co-dependent PRs:  
- https://github.com/bullet-train-co/bullet_train-base/pull/80
- (A PR in [bullet_train](https://github.com/bullet-train-co/bullet_train) should be added for tests)

This PR addresses the changes to the Stimulus controller:
- [X] Re-issue dragula events as native events

Note: this PR is on top of unmerged PR #6, which introduces the Stimulus controller. The merge target branch is `add-sortable-stimulus-controller` for that reason.